### PR TITLE
ongoing(options): Options Reorganization

### DIFF
--- a/deadlinks/__main__.py
+++ b/deadlinks/__main__.py
@@ -14,9 +14,9 @@
 
 """
 deadlinks.main
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
-main (cli interface)
+Main (cli interface)
 
 :copyright: (c) 2019 by Oleg Butuzov.
 :license:   Apache2, see LICENSE for more details.
@@ -38,13 +38,12 @@ from .exporters import exporters
 from .__version__ import __app_version__ as version
 from .__version__ import __app_package__ as name
 
-from .options import default_options
+from .options import default_options as general_options
 from .serving.options import default_options as serving_options
 
-from .clicker import register_options
-from .clicker import register_exports
-from .clicker import command
-from .clicker import argument
+from .clicker import (register_options, register_exports)
+from .clicker import Options
+from .clicker import (command, argument)
 
 
 @click.command(name, **command)
@@ -52,45 +51,30 @@ from .clicker import argument
 @click.version_option(message='%(prog)s: v%(version)s', prog_name=name, version=version)
 @register_exports(exporters)
 @register_options("Server Settings", serving_options)
-# keep default_options last in list of register_options decoratos
-@register_options("Default Options", default_options)
+@register_options("Default Options", general_options)
 @click.pass_context
-def main(ctx: click.Context, url: str, **opts: Dict[str, Any]) -> None:
+def main(ctx: click.Context, url: str, **opts: Options) -> None:
     """ Check links in your (web) documentation for accessibility. """
 
     try:
-        # TODO: Get Rid of this, in favor of **opts
-        # - [ ] Implement transformers
-
-        settings = Settings(
-            url,
-            **{
-                'check_external_urls': opts['external'],
-                'stay_within_path': not opts['full_site_check'],
-                'threads': opts['threads'],
-                'retry': opts['retry'],
-                'ignore_domains': opts['domains'],
-                'ignore_pathes': opts['pathes'],
-                # internal
-                'root': opts['root'],
-            })
+        settings = Settings(url, **opts)
         crawler = Crawler(settings)
 
         driver = exporters[str(opts['export'])]
 
         # Instantion of the exported before starting crawling will alow us to
-        # have prgress report, while we crawling website.
+        # have progress report, while we crawling website.
         exporter = driver(crawler, **opts)
 
         # Starting crawler
         crawler.start()
 
-        # And showing report of crawling, in 90% we not shoing anything
-        # untill crawling is done, so we can just output (pipe) data
+        # And showing report of crawling, in 90% we not showing anything
+        # un till crawling is done, so we can just output (pipe) data
         # to where user desire have results.
         exporter.report()
 
-        if opts['fiff'] and len(crawler.failed) > 0:
+        if opts['fail_if_fails_found'] and len(crawler.failed) > 0:
             ctx.exit(1)
 
     except DeadlinksExeption as e:

--- a/deadlinks/exporters/default.py
+++ b/deadlinks/exporters/default.py
@@ -9,6 +9,7 @@ import click
 
 from .export import Export
 from ..crawler import Crawler
+from ..clicker import OptionRaw
 
 BEFORE_BAR = '\r' if os_name == 'nt' else '\r\033[?25l'
 AFTER_BAR = '\n' if os_name == 'nt' else '\033[?25h\n'
@@ -49,43 +50,41 @@ class Default(Export):
         return message
 
     @staticmethod
-    def options() -> Tuple[str, List[Tuple[Tuple[str], Dict[str, Any]]]]:
+    def options() -> Tuple[str, List[OptionRaw]]:
 
-        name = "Exporter (default)"
-        options = [
-            # Default export
-            (
-                ('--export', ),
-                {
-                    'default': 'default',
-                    'hidden': True,
-                    'multiple': False,
-                    'type': click.Choice(['default'], case_sensitive=False),
-                    'help': 'Export type',
-                },
-            ),
-            # do not show colored output
-            (
-                ('--no-colors', ),
-                {
-                    'default': False,
-                    'is_flag': True,
-                    'help': 'Color output of `default` export',
-                },
-            ),
+        options = [] # type: List[OptionRaw]
 
-            # do not show colored output
-            (
-                ('--no-progress', ),
-                {
-                    'default': False,
-                    'is_flag': True,
-                    'help': 'Disable Proogresion output',
-                },
-            ),
-        ]
+        # Default export
+        options.append((
+            ('--export', ),
+            {
+                'default': 'default',
+                'hidden': True,
+                'multiple': False,
+                'type': click.Choice(['default'], case_sensitive=False),
+                'help': 'Export type',
+            },
+        ))
 
-        return (name, options)
+        options.append((
+            ('--no-colors', ),
+            {
+                'default': False,
+                'is_flag': True,
+                'help': 'Color output of `default` export',
+            },
+        ))
+
+        options.append((
+            ('--no-progress', ),
+            {
+                'default': False,
+                'is_flag': True,
+                'help': 'Disable Proogresion output',
+            },
+        ))
+
+        return ("Exporter (default)", options)
 
     def _progress_handler(self) -> None:
         """ progress handler desides states regarding crawler """

--- a/deadlinks/exporters/export.py
+++ b/deadlinks/exporters/export.py
@@ -28,17 +28,7 @@ from abc import ABC, abstractmethod
 from typing import (Dict, List, Tuple, Any)
 
 from ..crawler import Crawler
-"""
-class Sample(Export):
-
-    def __init__(self, crawler: Crawler, **opts: Dict) -> None:
-        self._crawler = crawler
-        self._opts = opts
-
-    def report(self) -> None:
-        print("Total", len(self._crawler.index))
-
-"""
+from ..clicker import OptionsList
 
 
 class Export(ABC):
@@ -50,7 +40,7 @@ class Export(ABC):
 
     @staticmethod
     @abstractmethod
-    def options() -> Tuple[str, List[Tuple[Tuple[str], Dict[str, Any]]]]:
+    def options() -> Tuple[str, OptionsList]:
         """ you need to implement report method """
         raise NotImplementedError
 

--- a/deadlinks/options.py
+++ b/deadlinks/options.py
@@ -16,98 +16,106 @@
 deadlinks.options
 ~~~~~~~~~~~~~~~~~
 
-default options to be consumed by click
+Default options to be consumed by click
 
 :copyright: (c) 2019 by Oleg Butuzov.
 :license:   Apache2, see LICENSE for more details.
 """
 
 from click import IntRange, Choice
+from typing import List
+from .clicker import OptionRaw
 
-default_options = [
+default_options = [] # type: List[OptionRaw]
 
-    # Index External URLs ------------------------------------------------------
-    (
-        ('-e', '--external'),
-        {
-            'default': False,
-            'is_flag': True,
-            'multiple': False,
-            'show_default': False,
-            'help': 'Enables external resources check',
-        },
-    ),
+# Index External URLs ------------------------------------------------------
+default_options.append((
+    ("check_external_urls", '-e', '--external'),
+    {
+        'default': False,
+        'is_flag': True,
+        'show_default': False,
+        'help': 'Enables external resources check',
+    },
+))
 
-    # Retries ------------------------------------------------------------------
-    (
-        ('-r', '--retry'),
-        {
-            'default': 0,
-            'type': IntRange(0, 10),
-            'is_flag': False,
-            'multiple': False,
-            'show_default': True,
-            'help': 'Number of retries (in case of error)',
-        },
-    ),
+# Retries ------------------------------------------------------------------
+default_options.append((
+    ('-r', '--retry'),
+    {
+        'default': 0,
+        'type': IntRange(0, 10),
+        'is_flag': False,
+        'show_default': True,
+        'metavar': '',
+        'help': 'Number of Retries [0...10]',
+    },
+))
 
-    # Retries ------------------------------------------------------------------
-    (
-        ('-n', '--threads'),
-        {
-            'default': 1,
-            'type': IntRange(1, 10),
-            'is_flag': False,
-            'multiple': False,
-            'show_default': True,
-            'help': 'Concurrent crawlers',
-        },
-    ),
+# Concurrent Crawlers ------------------------------------------------------
+default_options.append((
+    ('-n', '--threads'),
+    {
+        'default': 1,
+        'type': IntRange(1, 10),
+        'is_flag': False,
+        'show_default': True,
+        'metavar': '',
+        'help': 'Concurrent crawlers [1...10]',
+    },
+))
 
-    # Ignored Domains  ---------------------------------------------------------
-    (
-        ('-d', '--domains'),
-        {
-            'multiple': True,
-            'help': 'Domains to ignore',
-        },
-    ),
-    # Ignored Paths  -----------------------------------------------------------
-    (
-        ('-p', '--pathes'),
-        {
-            'multiple': True,
-            'help': 'Pathes to ignore',
-        },
-    ),
+# Ignored Domains  ---------------------------------------------------------
+default_options.append((
+    ('ignore_domains', '-d', '--domains'),
+    {
+        'multiple': True,
+        'metavar': '',
+        'help': 'Domain to ignore ()',
+    },
+))
 
-    # Disable path limiting for a local to the domain links.
-    (
-        ('--full-site-check', ),
-        {
-            'default': False,
-            'is_flag': True,
-            'help': 'Check links on domain not limiting',
-        },
-    ),
+# Ignored Paths  -----------------------------------------------------------
+default_options.append((
+    ('ignore_pathes', '-p', '--pathes'),
+    {
+        'multiple': True,
+        'metavar': '',
+        'help': 'Path to ignore ()',
+    },
+))
 
-    # Default export
-    (
-        ('-s', '--show'),
-        {
-            'default': ['failed'],
-            'multiple': True,
-            'type': Choice(['failed', 'ok', 'ignored', 'all', 'none'], case_sensitive=False),
-            'show_default': True,
-            'help': 'Category of URLs to show.',
-        },
-    ),
-    (
-        ('--fiff', ),
-        {
-            'default': False,
-            'is_flag': True,
-            'help': 'Fail if failed URLs are found',
-        },
-    ),
-]
+# Disable path limiting for a local to the domain links.
+default_options.append((
+    ('stay_within_path', '--full-site-check'),
+    {
+        'default': True,
+        'is_flag': True,
+        'help': 'Check full site',
+    },
+))
+
+# Show selectors.
+default_options.append((
+    ('show', '-s', '--show'),
+    {
+        'default': ['failed'],
+        'multiple': True,
+        'type': Choice(
+            ['failed', 'ok', 'ignored', 'all', 'none'],
+            case_sensitive=False,
+        ),
+        'show_default': False,
+        'metavar': '',
+        'help': 'Show results [failed (default), ok, ignored, all or none]',
+    },
+))
+
+default_options.append((
+    ('fail_if_fails_found', '--fiff'),
+    {
+        'default': False,
+        'is_flag': True,
+        'help': 'Fail if failed URLs are found',
+    },
+))

--- a/deadlinks/serving/options.py
+++ b/deadlinks/serving/options.py
@@ -14,23 +14,43 @@
 
 """
 deadlinks.serving.options
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-default options to be consumed by click
+Default options to be consumed by click if `internal` domain passed.
 
 :copyright: (c) 2019 by Oleg Butuzov.
 :license:   Apache2, see LICENSE for more details.
 """
+
 from click import Path
 
-default_options = [
+from typing import List
+from ..clicker import OptionRaw, Options
 
-    # root, in case of URL<internal>, defaults to . (pwd or current directory)
-    (
-        ('--root', ),
-        {
-            'help': 'Document Root for html files',
-            'type': Path(),
-        },
-    ),
-]
+
+def root_option_modifier(options: Options) -> Options:
+    """ this modifier will be triggered if root option passed. """
+
+    if not options["root"]:
+        return options
+
+    if options.get("retry", 0) == 0:
+        options["retry"] = 3
+
+    if options.get("threads", 1) == 1:
+        options["threads"] = 10
+
+    return options
+
+
+default_options = [] # type: List[OptionRaw]
+# root, in case of URL<internal>, defaults to . (pwd or current directory)
+default_options.append((
+    ('root', '-R', '--root'),
+    {
+        'help': 'Path to the documentation\'s Document Root',
+        'metavar': '',
+        'type': Path(),
+        'modifier': [root_option_modifier]
+    },
+))


### PR DESCRIPTION
Options reorganized with types, and small enhancements

* Introduction: `modifier` argument of List[Callable] type,
 desginated, to change other options, if this option passed.

* Better handling of Clicker groups (properties we use to
 group variables and modifiers)

* Implementation of `invoke`, to proxy changed to options/params.

* Code deduplication (within decorators of options handlers)

* Small styling changes (everywhere)