### PR TITLE
ongoing(cli): improving passing prog_name and default cli helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ docker-build-local: clean
 docker-check-local: docker-build-local
 	docker run --rm -it --network=host  butuzov/deadlinks:local --version
 
+# enable `--pull=alway` once it will be available https://github.com/docker/cli/pull/1498
+# status - 19.03 not avaialbe.
 docker-check-dev:
 	docker run --rm -it --network=host  butuzov/deadlinks:dev --version
 

--- a/deadlinks/__main__.py
+++ b/deadlinks/__main__.py
@@ -52,7 +52,7 @@ from .__version__ import __app_package__ as name
 
 @click.command(name, **command)
 @click.argument('url', **argument)
-@click.version_option(message='%(prog)s: v%(version)s', prog_name=name, version=version)
+@click.version_option(version, '-V', '--version', message='%(prog)s: v%(version)s', prog_name=name)
 @register_exports(exporters)
 @register_options("Server Settings", serving_options)
 @register_options("Default Options", general_options)

--- a/deadlinks/clicker.py
+++ b/deadlinks/clicker.py
@@ -33,6 +33,7 @@ from click import Command, Context
 from click import HelpFormatter as Formatter
 
 from .link import Link
+from .__version__ import __app_package__ as app
 
 # -- Typing Decorators -----~---------------------------------------------------
 OptionsValues = Union[str, bool, int, List[str], List[Callable]]
@@ -153,6 +154,13 @@ class Clicker(Command):
         self.format_options(ctx, formatter)
         self.format_epilog(ctx, formatter)
 
+    def make_context(self, info_name, args, parent=None, **extra) -> Context: # type: ignore
+        """ Hooking into context in oder to make pro_name for unnamed call. """
+
+        extra['help_option_names'] = ['--help', '-h']
+
+        return super().make_context(app, args, parent, **extra)
+
     def format_options(self, ctx: Context, formatter: Formatter) -> None:
         """ Group options together. """
 
@@ -197,7 +205,7 @@ class Clicker(Command):
                 formatter.write("  {}\n".format(line))
 
     def modify(self, ctx: Context) -> None:
-
+        """ Modifing params based on context. """
         if not self._modify:
             return
 
@@ -207,11 +215,8 @@ class Clicker(Command):
                     ctx.params = modify(ctx.params)
 
     def invoke(self, ctx: Context) -> None:
-
-        # print(self._modify)
-
+        """ Hooking into invoke in order to modify params. """
         self.modify(ctx)
-
         super().invoke(ctx)
 
 


### PR DESCRIPTION
* version can be triggered with -V
* help can be triggered with -h
* progname is deadlinks, even if it's called as `python -m deadlinks`