### PR TITLE
feature: Removing reppy dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deps: venv ## install requiements
 
 
 dev-env: deps clean ## Install Development Version
-	$(PYTHON) -m pip uninstall deadlinks -y
+	pip uninstall deadlinks -y
 	pip install -e .
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ idna>=2.8
 requests>=2.22.0
 click>=7.0
 urllib3>=1.25.6
-reppy==0.4.14
 six==1.15.0
 PyOpenSSL==19.1.0; python_full_version < '3.6.0'
 

--- a/tests/features/tests_robots.py
+++ b/tests/features/tests_robots.py
@@ -11,20 +11,15 @@ Tests robots.txt integration.
 # -- Imports -------------------------------------------------------------------
 
 import pytest
-from flaky import flaky
 
 from copy import deepcopy as copy
-from typing import (Optional, Dict)
+from typing import Dict
 
 from ..utils import Page
 
 from deadlinks import (Settings, Crawler)
-from deadlinks import user_agent
 
-from deadlinks import (
-    DeadlinksIgnoredURL,
-    DeadlinksSettingsBase,
-)
+from deadlinks import DeadlinksIgnoredURL
 
 server_pages = {
     '^/$': Page("".join(["<a href='/link-%s'>%s</a>" % (x, x) for x in range(1, 101)])).exists(),
@@ -97,13 +92,16 @@ def test_failed_domain():
     from random import choice
     from string import ascii_lowercase
 
-    domain = "http://%s.com/" % ''.join([choice(ascii_lowercase) for x in range(42)])
+    domain = "http://%s.com/" % ''.join(choice(ascii_lowercase) for x in range(42))
     c = Crawler(Settings(domain))
     c.start()
 
     assert len(c.failed) == 1
 
 
+# Allow is Deeper then Disallowed.
+# https://www.contentkingapp.com/blog/implications-of-new-robots-txt-rfc/
+# https://tools.ietf.org/html/draft-koster-rep-04
 def test_failed_google():
 
     c = Crawler(


### PR DESCRIPTION
Because of the `reppy` isn't supported anymore ( see https://github.com/seomoz/reppy/issues/122 ), it's functionality replaced by the default python module `urllib.robotparser.RobotFileParser` with a small google oriented extension.