### PR TITLE
chores: drop python 3.5 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
 
-  extras:
+  Static-Analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,18 +18,23 @@ jobs:
         with:
           python-version: "3.9"
 
-      # linters
-      - run: |
-          IP_ADDR=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}')
-          echo -e "${IP_ADDR} | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: make dev-env
       - run: make pylint-full
       - run: make mypy
-      # docs
+
+  Docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
       - run: make docs-build
 
-  build:
+  Build:
     runs-on: ubuntu-latest
+    needs: [ Static-Analysis, Docs ]
     strategy:
       fail-fast: false
       matrix:
@@ -46,12 +51,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: |
-          IP_ADDR=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}')
-          echo -e "${IP_ADDR} | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      # running dependencies
       - run: make dev-env
-      # testing dependencies
       - run: make tests
 
       - name: codecov.io

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ _centos_gawk_install:
 
 venv:
 	@ if [[ ! -z "${GITHUB_ENV}" ]]; then \
-		echo ">>>>> This is CI. Cplease Continue!";\
+		echo ">>>>> This is CI. Please Continue!";\
 		exit 0;\
 	elif [[   -z "${VIRTUAL_ENV}" ]]; then\
 		echo ">>>>> You need to run this test in virtual environment. Abort!";\

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_data() -> Dict[str, str]:
         raise RuntimeError("Can not find source for deadlinks/__version__.py")
 
     values = dict() # type: Dict[str, str]
-    with open(str(init)) as fh:
+    with open(init) as fh:
         content = "".join(fh.readlines())
         for match in DUNDER_REGEXP.findall(content):
             values[match[1]] = match[2]
@@ -45,7 +45,7 @@ def require(section: str = "install") -> List[str]:
         return []
 
     requires = defaultdict(list) # type: Dict[str, List[str]]
-    with open(str(require_txt), "rb") as fh:
+    with open(require_txt, "rb") as fh:
         key = "" # type: str
         for line in fh.read().decode("utf-8").split("\n"):
 

--- a/tests/features/tests_termination.py
+++ b/tests/features/tests_termination.py
@@ -36,7 +36,7 @@ def background_cli_runner(args, queue):
     queue.put(('output', result.output))
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=10)
 def test_terminition_click(server):
 
     url = server.router({'^/$': Page("").slow().exists()})

--- a/tests/utils/server.py
+++ b/tests/utils/server.py
@@ -56,12 +56,7 @@ class Server:
         return self.address, self.port,
 
     def host(self):
-        # h = socket.gethostbyname(socket.gethostname())
-        # print(f"host: {h}")
-
-        # reporary returning hardcodede string that points home.
-        # https://github.com/actions/virtual-environments/issues/3185
-        return "127.0.0.1"
+        return socket.gethostbyname(socket.gethostname())
 
     def router(self, config: RouterConfig = None):
 


### PR DESCRIPTION
1. restored ci pipeline and related tests (after issue fixed in Github)
2. added more retries for the flaky test
3. removed path to string conversation required by python 3.5
4. spelling